### PR TITLE
Make use of github actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os:
         - macOS-11
+        - macOS-12
         go:
         - 1.17
     steps:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,3 +26,8 @@ jobs:
         run: make
       - name: vet
         run: go vet ./...
+      - name: Upload vfkit artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vfkit Universal Binary (${{ matrix.os }})
+          path: "./out/vfkit"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,7 +13,7 @@ jobs:
         os:
         - macOS-11
         go:
-        - 1.16
+        - 1.17
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-    - "master"
+    - "main"
   pull_request: {}
 jobs:
   build:


### PR DESCRIPTION
This fixes the default branch name (it's 'main' not 'master') so that ghactions are useful. This also switches to go 1.17, and tests builds on macOS 12.