### PR TITLE
version: Add -dev suffix to denote pre-release

### DIFF
--- a/cmd/vfkit/root.go
+++ b/cmd/vfkit/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const vfkitVersion = "0.0.1"
+const vfkitVersion = "0.0.2-dev"
 
 var opts = &cmdlineOptions{}
 


### PR DESCRIPTION
I'll make a snapshot pre-release, -dev follows
https://semver.org/#spec-item-9